### PR TITLE
The "use strict", minor performance enhancements (the "for" statement), fix typo / style cleanup

### DIFF
--- a/content/menucommander.js
+++ b/content/menucommander.js
@@ -43,7 +43,7 @@ GM_MenuCommander.createMenuItem = function(command) {
 GM_MenuCommander.messageMenuCommandResponse = function(aMessage) {
   if (aMessage.data.cookie != GM_MenuCommander.cookieShowing) return;
 
-  for (i in aMessage.data.commands) {
+  for (var i in aMessage.data.commands) {
     var command = aMessage.data.commands[i];
     var menuItem = GM_MenuCommander.createMenuItem(command);
     GM_MenuCommander.popup.appendChild(menuItem);

--- a/content/scriptprefs.js
+++ b/content/scriptprefs.js
@@ -57,11 +57,11 @@ window.addEventListener('load', function() {
 }, false);
 
 function onDialogAccept() {
-  gScript.includes = gScriptIncludesEl.pages;
+  // gScript.includes = gScriptIncludesEl.pages;
   gScript.userIncludes = gUserIncludesEl.pages;
-  gScript.matches = gScriptMatchesEl.pages;
+  // gScript.matches = gScriptMatchesEl.pages;
   gScript.userMatches = gUserMatchesEl.pages;
-  gScript.excludes = gScriptExcludesEl.pages;
+  // gScript.excludes = gScriptExcludesEl.pages;
   gScript.userExcludes = gUserExcludesEl.pages;
   GM_util.getService().config._changed(gScript, "cludes");
 }

--- a/modules/abstractScript.js
+++ b/modules/abstractScript.js
@@ -1,14 +1,15 @@
 'use strict';
 
-const EXPORTED_SYMBOLS = ['AbstractScript'];
+var EXPORTED_SYMBOLS = ['AbstractScript'];
 
-const gAboutBlankRegexp = /^about:blank/;
+var gAboutBlankRegexp = /^about:blank/;
 
-const Cu = Components.utils;
+var Cu = Components.utils;
 
 Cu.import('chrome://greasemonkey-modules/content/third-party/convert2RegExp.js');
 Cu.import('chrome://greasemonkey-modules/content/third-party/MatchPattern.js');
 Cu.import('chrome://greasemonkey-modules/content/util.js');
+
 
 function AbstractScript() { }
 

--- a/modules/ipcscript.js
+++ b/modules/ipcscript.js
@@ -124,7 +124,11 @@ function updateData(data) {
   var newScripts = data.scripts.map(objectToScript);
   Object.freeze(newScripts);
   scripts = newScripts;
-  IPCScript.prototype.globalExcludes = data.globalExcludes;
+  Object.defineProperty(IPCScript.prototype, "globalExcludes", {
+    get: function () { return data.globalExcludes; },
+    configurable: true,
+    enumerable: true
+  });
 }
 
 

--- a/modules/ipcscript.js
+++ b/modules/ipcscript.js
@@ -105,7 +105,7 @@ IPCScript.prototype.info = function() {
 
 var scripts = [];
 
-const cpmm = Components.classes["@mozilla.org/childprocessmessagemanager;1"]
+var cpmm = Components.classes["@mozilla.org/childprocessmessagemanager;1"]
     .getService(Components.interfaces.nsISyncMessageSender);
 
 

--- a/modules/processScript.js
+++ b/modules/processScript.js
@@ -5,7 +5,7 @@
 // footprint for stateless things.  Avoid keeping references to frame scripts
 // or their content, this could leak frames!
 
-const EXPORTED_SYMBOLS = ['addFrame'];
+var EXPORTED_SYMBOLS = ['addFrame'];
 
 
 function addFrame(frameMM) {

--- a/modules/requestObserver.js
+++ b/modules/requestObserver.js
@@ -1,12 +1,13 @@
 'use strict';
 
-const EXPORTED_SYMBOLS = [];
+var EXPORTED_SYMBOLS = [];
 
 Components.utils.import("resource://gre/modules/Services.jsm");
 Components.utils.import("chrome://greasemonkey-modules/content/util.js");
 Components.utils.import("chrome://greasemonkey-modules/content/prefmanager.js");
 
-const types = Components.interfaces.nsIContentPolicy
+var types = Components.interfaces.nsIContentPolicy;
+
 
 function checkScriptRefresh(channel) {
   // .loadInfo is part of nsiChannel -> implicit QI needed

--- a/modules/script.js
+++ b/modules/script.js
@@ -217,16 +217,16 @@ Script.prototype.__defineGetter__('userMatches',
 function Script_getUserMatches() { return this._userMatches.concat(); });
 Script.prototype.__defineSetter__('userMatches',
 function Script_setUserMatches(matches) {
-  var matches_MatchPattern = new Array();
+  var matches_MatchPattern = [];
 
-  for (var i = 0; i < matches.length; i++) {
+  for (var i = 0, count = matches.length; i < count; i++) {
     var match = matches[i];
     try {
       var match_MatchPattern = new MatchPattern(match);
       matches_MatchPattern.push(match_MatchPattern);
     } catch (e) {
       GM_util.logError(stringBundle.GetStringFromName('parse.ignoring-match')
-                          .replace('%1', match).replace('%2', e));
+          .replace('%1', match).replace('%2', e));
     }
   }
   matches = matches_MatchPattern;
@@ -241,6 +241,24 @@ function Script_setUserExcludes(excludes) { this._userExcludes = excludes.concat
 
 Script.prototype.__defineGetter__('matches',
 function Script_getMatches() { return this._matches.concat(); });
+Script.prototype.__defineSetter__('matches',
+function Script_setMatches(matches) {
+  var matches_MatchPattern = [];
+
+  for (var i = 0, count = matches.length; i < count; i++) {
+    var match = matches[i];
+    try {
+      var match_MatchPattern = new MatchPattern(match);
+      matches_MatchPattern.push(match_MatchPattern);
+    } catch (e) {
+      GM_util.logError(stringBundle.GetStringFromName('parse.ignoring-match')
+          .replace('%1', match).replace('%2', e));
+    }
+  }
+  matches = matches_MatchPattern;
+
+  this._matches = matches.concat();
+});
 
 Script.prototype.__defineGetter__('requires',
 function Script_getRequires() { return this._requires.concat(); });


### PR DESCRIPTION
The suggestion (for example).

"use strict" - in Browser Console:
![1](https://cloud.githubusercontent.com/assets/2373486/10124580/77c4e002-6558-11e5-8a08-d0a4b3566809.png)
![2](https://cloud.githubusercontent.com/assets/2373486/10124581/77d5b2d8-6558-11e5-9f3f-8daac4501826.png)
![3](https://cloud.githubusercontent.com/assets/2373486/10124582/77d6808c-6558-11e5-84c3-e5613d5c4d88.png)
