### PR TITLE
Allow more contentType when detecting scripts

### DIFF
--- a/src/content/script-detect.js
+++ b/src/content/script-detect.js
@@ -8,7 +8,11 @@ the installation dialog is added, inside the content page.
 
 const userScriptTypes = {
   'text/plain': 1,
-  'application/x-javascript': 1
+  'application/ecmascript': 1,
+  'application/javascript': 1,
+  'application/x-javascript': 1,
+  'text/ecmascript': 1,
+  'text/javascript': 1,
   };
 
 if (document.contentType in userScriptTypes) {


### PR DESCRIPTION
`application/javascript` is the "correct" mime for javascript. But some others may also be accepted by browsers. HTML specification had given a list of MIME which may be considered as javascript file at https://html.spec.whatwg.org/multipage/scripting.html#javascript-mime-type . some of MIME given by the list just trigger a download action on firefox. we do not include theme. `text/plain` should not be readed as javascript, but it may be useful for install scripts from github with raw button.