### PR TITLE
grant should be checked before invoke GM_* functions

### DIFF
--- a/src/bg/user-script-registry.js
+++ b/src/bg/user-script-registry.js
@@ -83,6 +83,27 @@ function loadUserScripts() {
 };
 
 
+function checkUserScriptPermission(uuid, permission) {
+  if (!uuid) {
+    console.warn('checkUserScriptPermission need UUID to check permission.');
+    return false;
+  }
+  let userScript = userScripts[uuid];
+  if (!userScript) {
+    console.warn(
+      'checkUserScriptPermission got non-installed UUID:', uuid);
+    return false;
+  }
+  let grants = userScript.grants;
+  if (!Array.isArray(grants)) {
+    console.warn('checkUserScriptPermission failed grants is not an array.');
+    return false;
+  }
+  return grants.includes(permission);
+}
+window.checkUserScriptPermission = checkUserScriptPermission;
+
+
 function onEditorSaved(message, sender, sendResponse) {
   let userScript = userScripts[message.uuid];
   if (!userScript) {
@@ -123,8 +144,8 @@ window.onUserScriptGet = onUserScriptGet;
 
 
 function onApiGetResourceBlob(message, sender, sendResponse) {
-  if (!message.uuid) {
-    console.warn('onApiGetResourceBlob handler got no UUID.');
+  if (!checkUserScriptPermission(message.uuid, 'GM.getResourceUrl')) {
+    console.warn('GM.getResourceUrl not granted.');
   } else if (!message.resourceName) {
       console.warn('onApiGetResourceBlob handler got no resourceName.');
   } else if (!userScripts[message.uuid]) {

--- a/src/bg/value-store.js
+++ b/src/bg/value-store.js
@@ -35,8 +35,8 @@ function scriptStoreDb(uuid) {
 
 
 function onApiDeleteValue(message, sender, sendResponse) {
-  if (!message.uuid) {
-    console.warn('ApiDeleteValue handler got no UUID.');
+  if (!checkUserScriptPermission(message.uuid, 'GM.deleteValue')) {
+    console.warn('GM.deleteValue not granted.');
     return;
   } else if (!message.key) {
     console.warn('ApiDeleteValue handler got no key.');
@@ -64,8 +64,8 @@ window.onApiDeleteValue = onApiDeleteValue;
 
 
 function onApiGetValue(message, sender, sendResponse) {
-  if (!message.uuid) {
-    console.warn('ApiGetValue handler got no UUID.');
+  if (!checkUserScriptPermission(message.uuid, 'GM.getValue')) {
+    console.warn('GM.getValue not granted.');
     return;
   } else if (!message.key) {
     console.warn('ApiGetValue handler got no key.');
@@ -97,8 +97,8 @@ window.onApiGetValue = onApiGetValue;
 
 
 function onApiListValues(message, sender, sendResponse) {
-  if (!message.uuid) {
-    console.warn('ApiListValues handler got no UUID.');
+  if (!checkUserScriptPermission(message.uuid, 'GM.listValues')) {
+    console.warn('GM.listValues not granted.');
     return;
   }
 
@@ -123,8 +123,8 @@ window.onApiListValues = onApiListValues;
 
 
 function onApiSetValue(message, sender, sendResponse) {
-  if (!message.uuid) {
-    console.warn('ApiSetValue handler got no UUID.');
+  if (!checkUserScriptPermission(message.uuid, 'GM.setValue')) {
+    console.warn('GM.setValue not granted.');
     return;
   } else if (!message.key) {
     console.warn('ApiSetValue handler got no key.');


### PR DESCRIPTION
UserScript may simply copy functions from `api-provider-source.js` to enable GM_* function without grants. This should be considered as a security issues. We just ensure the specified UserScript had enabled given API by check it against its grants


```javascript
// ==UserScript==
// @name        name
// @description description
// @namespace   https://github.com/tiansh
// @include     *://*
// @version     1.0
// @grant       none
// ==/UserScript==

function GM_setValue(key, value) {
  return new Promise((resolve, reject) => {
    chrome.runtime.sendMessage({
      'key': key,
      'name': 'ApiSetValue',
      'uuid': GM_info.uuid,
      'value': value,
    }, result => {
      if (result !== undefined) {
        resolve(result);
      } else {
        console.warn('set value failed:', chrome.runtime.lastError);
        reject();
      }
    });
  });
}


function GM_getValue(key, defaultValue) {
  return new Promise((resolve, reject) => {
    chrome.runtime.sendMessage({
      'key': key,
      'name': 'ApiGetValue',
      'uuid': GM_info.uuid,
    }, result => {
      if (result !== undefined) {
        resolve(result)
      } else {
        resolve(defaultValue);
      }
    });
  });
}

async function main() {
  try {
    let setResult = await GM_setValue('key', 42);
    alert('SetValue: ' + setResult);
    let getResult = await GM_getValue('key', -1);
    alert('GetValue: ' + getResult);
  } catch (e) { alert(e); }
}

main()
```

the above userscript should not functional any more after this commit.


Support for `xhr` had not been added since this api seems not completed.