### PR TITLE
Set new userScript values on editor save

### DIFF
--- a/src/user-script-obj.js
+++ b/src/user-script-obj.js
@@ -278,12 +278,14 @@ window.EditableUserScript = class EditableUserScript
             });
 
             this._parsedDetails = newDetails;
+            _loadValuesInto(this, newDetails, userScriptKeys);
             this.calculateEvalContent();
             resolve();
           });
       if (updater.skip()) {
         console.log('updater has no added remotes to handle');
         this._parsedDetails = newDetails;
+        _loadValuesInto(this, newDetails, userScriptKeys);
         this.calculateEvalContent();
         resolve();
       }


### PR DESCRIPTION
When saving (ctrl+s) from the userScript editor the new values supplied in the meta block are not applied to the userScript object and therefore not saved. Using the same method that's in [updateFromDownloader](https://github.com/arantius/greasemonkey/blob/master/src/user-script-obj.js#L315) resolves the issue and the script metadata is saved.